### PR TITLE
shouldn it be 'iban' ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ gem "validates_iban"
 
 ```ruby
 class Account < ActiveRecord::Base
-  validates :iban_string, iban_field: true
+  validates :iban_string, iban: true
 end
 ```


### PR DESCRIPTION
... as the class is callen `IbanValidator` and not `IbanFieldValidator`... 
using `validates :iban_string, iban_field: true` causes `Unknown validator: 'IbanFieldValidator'`